### PR TITLE
fixed setuptools to be compatible with recent verions. Also allows in…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     author='Vittorio La Barbera, Fabio Pardo',
     author_email='vlabarbera@rvc.ac.uk, f.pardo@imperial.ac.uk',
     install_requires=['dm_control', 'lxml', 'numpy'],
+    packages=setuptools.find_packages(exclude=("data")),
     license='MIT',
     python_requires='>=3.6',
     keywords=['ostrichrl', 'musculoskeletal', 'biomechanics',


### PR DESCRIPTION
I noticed that the setup.py doesn't work with newer version of setuptools anymore. I changed it such that it's also possible to install ostrichrl from "git+https...", making it available as a proper dependency on projects.